### PR TITLE
ignore alternative channels; support private groups

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -89,6 +89,10 @@ func (bot *Bot) handleMopidyEvents() {
 }
 
 func (bot *Bot) handleMessage(msg *slack.Message) {
+	if (msg.Channel != nil && msg.Channel.Name != bot.config.SlackChannel) {
+		fmt.Println("ignoreing message from other chan")
+		return
+	}
 	for _, cmd := range bot.commands {
 		match := cmd.Match(msg.Text)
 

--- a/slack/objects.go
+++ b/slack/objects.go
@@ -21,11 +21,13 @@ type RtmResponse struct {
 	Team     Team       `json:"team"`
 	Users    []*User    `json:"users"`
 	Channels []*Channel `json:"channels"`
+	Groups   []*Channel `json:"groups"`
 }
 
 type Message struct {
 	User      *User    `json:"-"`
 	Channel   *Channel `json:"-"`
+	ChannelId string   `json:"channel"`
 	Text      string   `json:"text"`
 	Timestamp string   `json:"ts"`
 }


### PR DESCRIPTION
This is pretty much my first time writing real Go code, so it's probably not pretty.

This changes two things:
- Only accepts commands from specified channel.
- Allows musicbot to work with private groups.
